### PR TITLE
Edge support

### DIFF
--- a/selectize-plugin-a11y.js
+++ b/selectize-plugin-a11y.js
@@ -56,16 +56,19 @@ Selectize.define("selectize-plugin-a11y", function (options) {
         });
       });
       observer.observe(self.$dropdown[0], {
+        attributes: true,
         attributeFilter: ["class"],
         subtree: true,
         attributeOldValue: true
       });
 
       observer.observe(self.$control[0], {
+        attributes: true,
         attributeFilter: ["class"]
       });
 
       observer.observe(self.$control_input[0], {
+        attributes: true,
         attributeFilter: ["value"]
       });
     },


### PR DESCRIPTION
This plugin was failing for me on Edge with the following console output:

`Unhandled promise rejection: SyntaxError`

It turns out, Edge requires an additional options (`attributes: true`) if `attributeFilter` is used. More info here: https://stackoverflow.com/questions/50593385/mutationobserver-syntax-error-on-ie-11