### PR TITLE
Escape text containing html

### DIFF
--- a/examples/api.html
+++ b/examples/api.html
@@ -16,6 +16,7 @@
         <option value="it">Italy</option>
         <option value="fr">France</option>
         <option value="gb">United Kingdom</option>
+        <option value="script">&lt;script&gt;alert('hi')&lt;/script&gt;</option>
     </select>
 
 
@@ -28,7 +29,7 @@
             render: {
                 option: function($item, escape) {
                     // Every option must have a unique id
-                    return `<div class="option" role="option" id="${$item.text.replace(' ', '')}">${$item.text}</div>`
+                    return `<div class="option" role="option" id="${escape($item.text).replace(' ', '')}">${escape($item.text)}</div>`
                 }
             }
         });

--- a/selectize-plugin-a11y.js
+++ b/selectize-plugin-a11y.js
@@ -25,7 +25,7 @@ Selectize.define("selectize-plugin-a11y", function (options) {
   self.accessibility.liveRegion = {
     $region: "",
     speak: function (msg) {
-      var $msg = $("<div>" + msg + "</div>");
+      var $msg = $("<div>" + escape(msg) + "</div>");
       this.$region.html($msg);
     },
     domListener: function () {


### PR DESCRIPTION
If you rely on calling an API to get your options data you might get something like: "<script>alert('hi')</script".

This will be run if you use the plugin.

My change escape the text so it can safely be used in the select.