### PR TITLE
Fix XSS vulnerability

### DIFF
--- a/selectize-plugin-a11y.js
+++ b/selectize-plugin-a11y.js
@@ -25,8 +25,9 @@ Selectize.define("selectize-plugin-a11y", function (options) {
   self.accessibility.liveRegion = {
     $region: "",
     speak: function (msg) {
-      var $msg = $("<div>" + msg + "</div>");
-      this.$region.html($msg);
+      var $container = $("<div></div>");
+      $container.text(msg);
+      this.$region.html($container);
     },
     domListener: function () {
       var observer = new MutationObserver(function (mutations) {


### PR DESCRIPTION
**Description**
Any HTML contained in `msg` will be rendered in the dom. This creates an XSS vulnerability if `msg` could be user input. 

**Solution**
Insert `msg` as text. This will just display the string as is without trying to render any possible HTML contained within it. 